### PR TITLE
added jsonp to mimemap

### DIFF
--- a/R/mime.R
+++ b/R/mime.R
@@ -59,6 +59,7 @@ local({
 #' @format NULL
 mimeextra = c(
   geojson = "application/vnd.geo+json",
+  jsonp = "application/javascript",
   r = "text/plain",
   rd = "text/plain",
   rmd = "text/x-markdown",


### PR DESCRIPTION
Had trouble when trying to load jsonp produced by trelliscopejs on a server that is prevented from guessing the content type.  This appeared to resolve the issue. 