### PR TITLE
Replace peter-evans/create-pull-request with gh CLI

### DIFF
--- a/.github/workflows/update-mimemap.yml
+++ b/.github/workflows/update-mimemap.yml
@@ -7,6 +7,10 @@ on:
 
 name: Update mimemap
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-mimemap:
     runs-on: ubuntu-latest
@@ -20,16 +24,23 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@HEAD
 
-      - run: |
-          Rscript tools/update.R
-          echo "OS_INFO=$(uname -sr)" >> $GITHUB_ENV
+      - run: Rscript tools/update.R
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@HEAD
-        with:
-          title: Update mimemap
-          body: Update mimemap by running `tools/update.R`.
-          commit-message: Update mimemap from ${{ env.OS_INFO }}
-          add-paths: |
-            R/mimemap.R
-            R/mimeextra.R
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet R/mimemap.R R/mimeextra.R; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          branch="update-mimemap"
+          git checkout -b "$branch"
+          git add R/mimemap.R R/mimeextra.R
+          git commit -m "Update mimemap from $(uname -sr)"
+          git push -u origin "$branch" --force
+          if ! gh pr list --head "$branch" --state open | grep -q .; then
+            gh pr create --title "Update mimemap" --body "Update mimemap by running \`tools/update.R\`."
+          fi


### PR DESCRIPTION
## Summary
- Removes the `peter-evans/create-pull-request` third-party action dependency
- Uses `git` + `gh pr create` directly instead
- Uses a fixed branch name (`update-mimemap`) and force-pushes to it on each run
- Only creates a new PR if one isn't already open

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and verify it either no-ops (if no mimemap changes) or creates/updates a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)